### PR TITLE
Clarifications to time off policy and official holidays

### DIFF
--- a/src/_peopleops/benefits.md
+++ b/src/_peopleops/benefits.md
@@ -43,8 +43,13 @@ We offer a 1 month paid sabbatical every 2 years of your employment. All full ti
 
 Taking more than 3 weeks consecutively requires explicit approval outside of the 2-yearly sabbatical. In other words, anything up to 3 business weeks can be taken off without approval.
 
-To log time off, team members should use [PTO by Roots](/company/tech-stack/#pto-by-roots) in Slack (under Apps).
+To log time off, team members should use [PTO by Roots](/company/tech-stack/#pto-by-roots) in Slack (under Apps).  Please try to do so **at least 2 weeks** prior to the date(s) you intend to take off.
+
 Follow the instructions in [Tracking Time Off](/peopleops/calendars#tracking-time-off) to indicate your PTO.
+
+#### Holidays
+
+Holidays vary by country and are not generally celebrated by all of Meltano at once.  The only all-Meltano days off are Family & Friends days.  Please follow the instructions in Follow the instructions in [Tracking Time Off](/peopleops/calendars#tracking-time-off) to log your holidays.
 
 #### Caregiver leave
 

--- a/src/_peopleops/benefits.md
+++ b/src/_peopleops/benefits.md
@@ -49,7 +49,7 @@ Follow the instructions in [Tracking Time Off](/peopleops/calendars#tracking-tim
 
 #### Holidays
 
-Holidays vary by country and are not generally celebrated by all of Meltano at once.  The only all-Meltano days off are Family & Friends days.  Please follow the instructions in Follow the instructions in [Tracking Time Off](/peopleops/calendars#tracking-time-off) to log your holidays.
+Holidays vary by country and are not generally celebrated by all of Meltano at once.  The only all-Meltano days off are Family & Friends days.  Please follow the instructions in [Tracking Time Off](/peopleops/calendars#tracking-time-off) to log your holidays.
 
 #### Caregiver leave
 

--- a/src/_peopleops/calendars.md
+++ b/src/_peopleops/calendars.md
@@ -16,7 +16,7 @@ weight: 2
 
 ## Tracking Time Off
 
-Use [PTO by Roots](/company/tech-stack/#pto-by-roots) to add time off to the calendar, preferably **at least 2 weeks** before the day off.  Holidays, Family and Friend Days, and Paid Time Off (PTO) are all tracked via this tool.  It is incumnbent upon everyone to add time off to the calendar in advance so the team knows who will be out when and can plan accordingly.
+Use [PTO by Roots](/company/tech-stack/#pto-by-roots) to add time off to the calendar, preferably **at least 2 weeks** before the day off.  Holidays, Family and Friend Days, and Paid Time Off (PTO) are all tracked via this tool.  It is important for everyone to add time off to the calendar in advance so the team knows who will be out when and can plan accordingly.
 
 ### Short-term Leave
 

--- a/src/_peopleops/calendars.md
+++ b/src/_peopleops/calendars.md
@@ -16,7 +16,7 @@ weight: 2
 
 ## Tracking Time Off
 
-Holidays, Family and Friend Days, and Paid Time Off (PTO) are all tracked via [PTO by Roots](/company/tech-stack/#pto-by-roots).
+Use [PTO by Roots](/company/tech-stack/#pto-by-roots) to add time off to the calendar, preferably at least 2 weeks before the day off.  Holidays, Family and Friend Days, and Paid Time Off (PTO) are all tracked via this tool.  It is incumnbent upon everyone to add time off to the calendar in advance so the team knows who will be out when and can plan accordingly.
 
 ### Short-term Leave
 

--- a/src/_peopleops/calendars.md
+++ b/src/_peopleops/calendars.md
@@ -16,7 +16,7 @@ weight: 2
 
 ## Tracking Time Off
 
-Use [PTO by Roots](/company/tech-stack/#pto-by-roots) to add time off to the calendar, preferably at least 2 weeks before the day off.  Holidays, Family and Friend Days, and Paid Time Off (PTO) are all tracked via this tool.  It is incumnbent upon everyone to add time off to the calendar in advance so the team knows who will be out when and can plan accordingly.
+Use [PTO by Roots](/company/tech-stack/#pto-by-roots) to add time off to the calendar, preferably **at least 2 weeks** before the day off.  Holidays, Family and Friend Days, and Paid Time Off (PTO) are all tracked via this tool.  It is incumnbent upon everyone to add time off to the calendar in advance so the team knows who will be out when and can plan accordingly.
 
 ### Short-term Leave
 


### PR DESCRIPTION
Policies to add to the handbook:

- Holidays vary by country the only all-Meltano ones are F&F day
- Take off what is legally required in your country
- Use PTO Roots to add time off to the calendar, preferably at least 2 weeks before the day off
