### PR TITLE
Fix links to gitlab to point at GitHub

### DIFF
--- a/src/_company/all-remote.md
+++ b/src/_company/all-remote.md
@@ -18,7 +18,7 @@ Of course, we move things over to our own handbook (which you are reading right 
 
 # Where we hire
 
-Our [team](https://meltano.com/about) is currently distributed over the United States, Mexico, and the United Kingdom.
+Our [team](https://meltano.com/about) is currently distributed across the United States, Mexico, Canada, the Dominican Republic, Germany, and the United Kingdom.
 We hope to keep growing that list until we cover all continents and time zones.
 
 To hire globally, we use [Remote](https://remote.com), who currently provide service in over 50 countries with dozens being added every year.

--- a/src/_company/communication.md
+++ b/src/_company/communication.md
@@ -142,14 +142,13 @@ If Zoom is down one can use Slack for calls between team members. To use Slack c
 
 ## Custom Emoji
 
-We use emoji to help convey emotions and ideas quickly. You should feel empowered to add any emoji you like, just consider the entire community and keep them appropriate and generally unoffensive.
+We use emoji to help convey emotions and ideas quickly. You should feel empowered to add any emoji you like, just consider the entire community and keep them appropriate and unoffensive.
 
+### Slack Custom Emoji
 Within Slack, it is possible to add emojis via the [customize interface](https://meltano.slack.com/customize/emoji).
-Within GitHub it is possible to add emojis [as described here](https://github.com/ikatyang/emoji-cheat-sheet#emoji-cheat-sheet).
 
 ### GitHub Custom Emoji
-
-GitHub supports custom emoji [tthrough scripts such as this linked example](https://github.com/StylishThemes/GitHub-Custom-Emojis).
+GitHub supports custom emoji [through scripts such as this linked example](https://github.com/StylishThemes/GitHub-Custom-Emojis).
 
 ## Giving and Receiving Feedback
 

--- a/src/_company/communication.md
+++ b/src/_company/communication.md
@@ -145,50 +145,11 @@ If Zoom is down one can use Slack for calls between team members. To use Slack c
 We use emoji to help convey emotions and ideas quickly. You should feel empowered to add any emoji you like, just consider the entire community and keep them appropriate and generally unoffensive.
 
 Within Slack, it is possible to add emojis via the [customize interface](https://meltano.slack.com/customize/emoji).
+Within GitHub it is possible to add emojis [as described here](https://github.com/ikatyang/emoji-cheat-sheet#emoji-cheat-sheet).
 
-### GitLab Custom Emoji
+### GitHub Custom Emoji
 
-GitLab also supports [custom emoji](https://docs.gitlab.com/ee/api/graphql/custom_emoji.html), though it is harder to add new ones.
-
-First navigate to [`GraphiQL`](https://gitlab.com/-/graphql-explorer) where you are able to execute GraphQL commands.
-
-The command to add a new emoji is:
-
-```graphql
-mutation {
-  createCustomEmoji(
-    input: { groupPath: "meltano", name: "<emoji-name>", url: "<emoji-url>" }
-  ) {
-    customEmoji {
-      name
-    }
-    errors
-  }
-}
-```
-
-to get a list of all emojis available, use this query:
-
-```graphql
-query GetCustomEmoji {
-  group(fullPath: "meltano") {
-    id
-    customEmoji {
-      nodes {
-        name
-        url
-      }
-    }
-  }
-}
-```
-
-Currently available GitLab custom emojis are:
-
-- `melty-flame`
-- `tanuki`
-
-Use them in comments or descriptions by typing `:emoji-name:`. Unfortunately, autocomplete and reactions (award emojis) are not currently supported for Custom Emojis.
+GitHub supports custom emoji [tthrough scripts such as this linked example](https://github.com/StylishThemes/GitHub-Custom-Emojis).
 
 ## Giving and Receiving Feedback
 
@@ -204,7 +165,7 @@ Positive feedback is critical for learning. People are often quick to notice wha
 
 **Best Venue:** Public channels, directly to their manger or them.
 
-**Examples:** Melty I have observed you taking charge of this project and i am so impressed with how proactive you have been involving stakeholders early and how you communicate with them. Keep it up.
+**Examples:** Melty, I have observed you taking charge of this project and I am so impressed with how proactive you have been involving stakeholders early and how you communicate with them. Keep it up!
 
 #### Constructive
 
@@ -216,7 +177,7 @@ Make sure you leave time when giving feedback to allow the person to ask clarify
 
 **Best Venue**: 1:1
 
-**Examples:** Melty we are super happy with the results of this project but in the process of getting it over the finish line you seemed ot alienate some of your peers by excluding them in the decision making. We want to see you build yourself as a leader and often that involves bringing people up with you and being a mentor which we kow you ar capable of. Let’s talk about how we can try to involve other more going forward.
+**Examples:** Melty, we are super happy with the results of this project but in the process of getting it over the finish line you seemed ot alienate some of your peers by excluding them in the decision making. We want to see you build yourself as a leader.  Often that involves bringing people up with you and being a mentor which we kow you ar capable of. Let’s talk about how we can try to involve others more going forward.
 
 #### Checking in / Reminders
 
@@ -224,7 +185,7 @@ Technically this is not feedback, but it can be construed as such if not given i
 
 Managers should be sensitive to the power dynamics potentially at play in any potential feedback engagement. They should consciously compensate for that dynamic in their communication. This can often come into play when sending reminders. Things can come across as a reprimand vs a reminder if one does not that this into account.
 
-**Example approach:** Hey I was looking for the latest info on project xyz and didn’t see anything new in the issue is it possible to find out the latest.
+**Example approach:** Hey I was looking for the latest info on project _xyz_ and didn’t see anything new in the issue. Is it possible to find out the latest?
 
 - This is good because you have already done your homework to see if the info is out there, you are not accusing them of anything and you are just trying to gather info. Even better add a timeline to your request if you have one so people can know how o prioritize the request appropriately.
 

--- a/src/_company/tech-stack.md
+++ b/src/_company/tech-stack.md
@@ -68,15 +68,14 @@ Domain name registration of `meltano.app`.
 
 Account details are in the `Engineering` 1Password vault.
 
-## [GitHub](https://github.com/)
+## [GitHub](https://github.com/meltano/)
 
-Software development and version control provider.
-
-## [GitLab](https://gitlab.com/meltano/)
-
-DevOps platform.
-
+DevOps platform - Software development and version control provider. 
 Every team member has their own account.
+
+<!--## [GitLab](https://gitlab.com/meltano/)
+
+Meltano's former DevOps platform.  All repos have been migrated to GitHub. -->
 
 ## [Google Ads](https://ads.google.com/)
 
@@ -193,7 +192,7 @@ Account details are in the `Engineering` 1Password vault.
 
 ## [Netlify](https://www.netlify.com/)
 
-Feature branch previews for <https://gitlab.com/meltano/meltano> docs.
+Feature branch previews for <https://github.com/meltano/meltano> docs.
 
 Account details are in the `Engineering` 1Password vault.
 
@@ -234,7 +233,7 @@ Account details are in the `Finance` 1Password vault.
 
 ## [Read the Docs](https://readthedocs.org/)
 
-Docs hosting for <https://gitlab.com/meltano/sdk>: <https://sdk.meltano.com>.
+Docs hosting for <https://github.com/meltano/sdk>: <https://sdk.meltano.com>.
 
 Account details are in the `Engineering` 1Password vault.
 

--- a/src/_company/using-github.md
+++ b/src/_company/using-github.md
@@ -42,7 +42,7 @@ In line with our [Together we thrive](/company/values#together-we-thrive) value,
   before and/or after implementing an important user-facing feature.
 - [Demo Day](https://gitlab.com/groups/meltano/-/boards/3650469) - used to better plan what will be presented from the Meltano team and community
 -->
-- [Engineering Assignment](https://github.com/orgs/meltano/projects/3) - useful for understanding the WIP for engineers in the company.
+- [Engineering Assignment](https://github.com/orgs/meltano/projects/3) - Useful for understanding the WIP for engineers in the company.
 - [Iterations](https://github.com/orgs/meltano/projects/3/views/4) - Engineering assignments by iteration.  Useful for understanding development scheduled on a weekly basis
 
 <!-- DOES NOT EXIST IN GITHUB?

--- a/src/_company/using-github.md
+++ b/src/_company/using-github.md
@@ -1,34 +1,35 @@
 ---
 layout: page
-title: Using GitLab to Track Work
+title: Using GitHub to Track Work
 weight: 2
 ---
 
-At Meltano, we use GitLab to track everything that needs to (one day) be done or discussed.
+At Meltano, we use GitHub to track everything that needs to (one day) be done or discussed.
 
 ## Issue Trackers
 
 In line with our [Together we thrive](/company/values#together-we-thrive) value, most of these trackers and the issues they hold are public so that our entire community can participate.
-If an issue fits best in a public tracker but should be private anyway, use a [confidential issue](https://docs.gitlab.com/ee/user/project/issues/confidential_issues.html).
 
-- [Meta (`meltano/meta`)](https://gitlab.com/meltano/meta/-/issues): Public issue tracker for **meta-level topics** around the team, company, or community that don't concern a specific [product](#product-specific) and don't fit in any other project. Use confidential issues as needed.
-- [Handbook (`meltano/handbook`)](https://gitlab.com/meltano/handbook/-/issues): Public issue tracker for **process and policy proposals** that will be documented in the public [company handbook](https://handbook.meltano.com/). Use confidential issues as needed.
+<!-- THIS DOES NOT EXIST WITHIN GITHUB
+- [Meta (`meltano/meta`)](https://gitlab.com/meltano/meta/-/issues): Public issue tracker for **meta-level topics** around the team, company, or community that don't concern a specific [product](#product-specific) and don't fit in any other project. Use confidential issues as needed. -->
+- [Handbook (`meltano/handbook`)](https://github.com/meltano/handbook/issues): Public issue tracker for **process and policy proposals** that will be documented in the public [company handbook](https://handbook.meltano.com/). <!-- Use confidential issues as needed. DO WE WISH TO DOCUMENT WHERE CONFIDENTIAL ITEMS ARE TRACKED? -->
 
 ### Subject-specific
 
-- [Administration (`meltano/administration`)](https://gitlab.com/meltano/administration/-/issues): Private issue tracker for **administrative tasks** related to running the business. Used primarily by CEO and Operations Analyst.
-- [Hiring (`meltano/hiring`)](https://gitlab.com/meltano/hiring/-/issues): Private issue tracker for **hiring topics**: hiring plans, job openings, and interview processes. Repository contains processes, questions, and exercises.
-- [Marketing (`meltano/marketing/marketing-general`)](https://gitlab.com/meltano/marketing/marketing-general/-/issues): Public issue tracker for **all things marketing**. Use confidential issues as needed.
+- [Administration (`meltano/administration`)](https://github.com/meltano/administration/issues): Private issue tracker for **administrative tasks** related to running the business. Used primarily by CEO and Operations Analyst.
+- [Hiring (`meltano/hiring-process`)]([https://github.com/meltano/hiring/issues](https://github.com/meltano/hiring-process/issues)): Private issue tracker for **hiring topics**: hiring plans, job openings, and interview processes. Repository contains processes, questions, and exercises.
+- [Marketing (`meltano/internal-marketing/`)](https://github.com/meltano/internal-marketing/issues/): Private issue tracker for **all things marketing**.
 
 ### Product-specific
 
-- [Meltano (`meltano/meltano`)](https://gitlab.com/meltano/meltano/-/issues)
-- [Meltano SDK (`meltano/sdk`)](https://gitlab.com/meltano/sdk/-/issues)
-- [MeltanoHub (`meltano/hub`)](https://gitlab.com/meltano/hub/-/issues)
-- [Meltano Squared (`meltano/squared`)](https://gitlab.com/meltano/squared/-/issues)
+- [Meltano (`meltano/meltano`)](https://github.com/meltano/meltano/issues)
+- [Meltano SDK (`meltano/sdk`)](https://github.com/meltano/sdk/issues)
+- [MeltanoHub (`meltano/hub`)](https://github.com/meltano/hub/issues)
+- [Meltano Squared (`meltano/squared`)](https://github.com/meltano/squared/issues)
 
-## Useful Issue Boards
+## Useful Project Boards
 
+<!--  THESE ARE WHAT WE HAD WHEN THIS SECTION LISTED GITLAB ISSUE BOARDS - PRESERVED HERE SO WE CAN REPLICATE WHERE POSSIBLE:
 - [Development Flow](https://gitlab.com/groups/meltano/-/boards/536761), with a column for each `flow::` label. Don't forget to filter by milestone, and/or assignee!
 - [Engineering Assignments](https://gitlab.com/groups/meltano/-/boards/3546394?not[label_name][]=valuestream::Business+Operation&not[label_name][]=kind::Non-Product&iteration_id=Current) - useful for understanding the WIP for engineers in the company.
 - [Iterations](https://gitlab.com/groups/meltano/-/boards/3831997?not[label_name][]=valuestream::Business+Operation&not[label_name][]=kind::Non-Product) - useful for understanding development scheduled on a weekly basis
@@ -39,13 +40,18 @@ If an issue fits best in a public tracker but should be private anyway, use a [c
 - [Office Hours](https://gitlab.com/groups/meltano/-/boards/2923184) - used to tee up issues for community discussion and review, generally directly
   before and/or after implementing an important user-facing feature.
 - [Demo Day](https://gitlab.com/groups/meltano/-/boards/3650469) - used to better plan what will be presented from the Meltano team and community
+-->
+- [Engineering Assignment](https://github.com/orgs/meltano/projects/3) - useful for understanding the WIP for engineers in the company.
+- [Iterations](https://github.com/orgs/meltano/projects/3/views/4) - Engineering assignments by iteration.  Useful for understanding development scheduled on a weekly basis
+
+<!-- DOES NOT EXIST IN GITHUB?
 
 ## Epics
 
 When appropriate, house an issue under an existing epic: <https://gitlab.com/groups/meltano/-/epics>
 
 New epics can be created for topics or efforts that will take multiple issues over multiple sprints.
-
+--> 
 ## Labels
 
 ### Flow Labels
@@ -199,22 +205,22 @@ Issues that are in a dated milestone indicate the "rough delivery window" of whe
 
 ## Iterations
 
-Once an issue becomes a priority, a sprint [iteration](https://gitlab.com/groups/meltano/-/iterations) is set (identified by the Friday of the week in question), even if it's still weeks away and may end up being moved.
+Once an issue becomes a priority, a sprint [iteration](https://github.com/orgs/meltano/projects/3/views/4) is set (identified by the Friday of the week in question), even if it's still weeks away and may end up being moved.
 
 New iterations are created about 6 weeks in advance as part of preparation for the weekly kickoff meeting.
 
-Check out the GitLab documentation on [Iterations](https://docs.gitlab.com/ee/user/group/iterations/#iterations) to better understand the differences between iterations and milestones.
+Check out the GitHub documentation on [Iterations](https://docs.github.com/en/enterprise-cloud@latest/issues/trying-out-the-new-projects-experience/managing-iterations) to better understand the differences between iterations and milestones.
 
 ### Best Practices
 
 The Product team manages all iterations.
-They can only be made at the group level, they always have a start and end date, and the date ranges cannot overlap.
+They can only be made at the project level, they always have a start and end date, and the date ranges cannot overlap.
 
 Anyone can add an issue to an iteration, but at the end of the issue, all incomplete issues will be rolled to the next iteration by Product.
 
 ## Issue Sizing
 
-The team uses Gitlab's `weight` feature to align on rough estimates of relative size. We bias towards
+The team uses Github's `weight` feature to align on rough estimates of relative size. We bias towards
 a system where most increments are double of the prior increment, to avoid debates of "is this a 2 or a 3?"
 and to acknowledge these are only low-precision estimates. The used values are: `1`, `2`, `4`, `8`, `12`,
 `20`, and `40`.
@@ -232,7 +238,7 @@ Sizing should always take into account these three factors:
  8 - Roughly 2-4 days work
 12 - Likely >=1 week and <=2 weeks
 20 - Should be broken to smaller deliverables if possible
-40 - Probably an epic, to be planned out in smaller deliverables
+40 - Probably needs to be planned out in smaller deliverables
 ```
 
 ### Why do we size issues?

--- a/src/_company/using-github.md
+++ b/src/_company/using-github.md
@@ -185,11 +185,14 @@ New labels can be created as appropriate at the Group Level and should be docume
 
 ## Milestones
 
-Milestones have a few different goals.
-Product manages all date-defined milestones (May 2022, 2022-Q2, etc.).
-Dated milestones are defined _only_ at the [group level](https://gitlab.com/groups/meltano/-/milestones).
-Anyone else can create a non-dated milestone for their own purposes at the group or project level.
+[Milestones](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones) are used to track progress on groups of issues or pull requests within a repository.  They are defined at the repository level.
 
+### Useful milestones
+
+- [Meltano repository](https://github.com/meltano/meltano/milestones)
+- [Hub repository](https://github.com/meltano/hub/milestones)
+
+<!-- NOT SURE HOW TO BEST UPDATE THIS:
 ### Best Practices
 
 At the end of every dated milestone, the Product team will roll all issues to the next dated milestone.
@@ -201,7 +204,7 @@ If something we want to happen eventually is not a priority yet, use `Backlog`.
 If there is an issue we want to start prioritizing, there is a `Staging` milestone which can be used to alert the Product Lead that this is something we'd like to move into an upcoming milestone or iteration.
 If we don't want it to happen, close the issue.
 
-Issues that are in a dated milestone indicate the "rough delivery window" of when we aim to deliver the issue.
+Issues that are in a dated milestone indicate the "rough delivery window" of when we aim to deliver the issue. -->
 
 ## Iterations
 

--- a/src/_company/using-github.md
+++ b/src/_company/using-github.md
@@ -8,16 +8,17 @@ At Meltano, we use GitHub to track everything that needs to (one day) be done or
 
 ## Issue Trackers
 
-In line with our [Together we thrive](/company/values#together-we-thrive) value, most of these trackers and the issues they hold are public so that our entire community can participate.
+In line with our [Together we thrive](/company/values#together-we-thrive) value, most of our trackers and the issues they hold are public so that our entire community can participate. The most commonly used non-product trackers are the following:
+- [Meltano (`meltano/handbook`)](https://github.com/meltano/handbook/issues): Public issue tracker for **process and policy proposals** that will be documented in the public [company handbook](https://handbook.meltano.com/).
+- [Meltano (`meltano/internal-general`)](https://github.com/meltano/internal-general/issues): Internal issue tracker for topics around the team & company
 
 <!-- THIS DOES NOT EXIST WITHIN GITHUB
 - [Meta (`meltano/meta`)](https://gitlab.com/meltano/meta/-/issues): Public issue tracker for **meta-level topics** around the team, company, or community that don't concern a specific [product](#product-specific) and don't fit in any other project. Use confidential issues as needed. -->
-- [Handbook (`meltano/handbook`)](https://github.com/meltano/handbook/issues): Public issue tracker for **process and policy proposals** that will be documented in the public [company handbook](https://handbook.meltano.com/). <!-- Use confidential issues as needed. DO WE WISH TO DOCUMENT WHERE CONFIDENTIAL ITEMS ARE TRACKED? -->
 
 ### Subject-specific
 
-- [Administration (`meltano/administration`)](https://github.com/meltano/administration/issues): Private issue tracker for **administrative tasks** related to running the business. Used primarily by CEO and Operations Analyst.
-- [Hiring (`meltano/hiring-process`)]([https://github.com/meltano/hiring/issues](https://github.com/meltano/hiring-process/issues)): Private issue tracker for **hiring topics**: hiring plans, job openings, and interview processes. Repository contains processes, questions, and exercises.
+- [Administration (`meltano/administration`)](https://github.com/meltano/administration/issues): Private issue tracker for **administrative tasks** related to running the business. Used primarily by CEO and Head of Operations.
+- [Hiring (`meltano/hiring-process`)](https://github.com/meltano/hiring-process/issues): Private issue tracker for **hiring topics**: hiring plans, job openings, and interview processes. Repository contains processes, questions, and exercises.
 - [Marketing (`meltano/internal-marketing/`)](https://github.com/meltano/internal-marketing/issues/): Private issue tracker for **all things marketing**.
 
 ### Product-specific

--- a/src/_peopleops/benefits.md
+++ b/src/_peopleops/benefits.md
@@ -196,15 +196,15 @@ We are happy to cover the cost of internet in your working place. This can be yo
 
 ### Team offsites
 
-Every nine months, we get the whole team together somewhere on the planet for Meltano Assemble.
+Approximately every nine months, we get the whole team together somewhere on the planet for Meltano Assemble.
 
-Assemble 2021 took place in beautiful Mexico City. The next event will be held in Lisbon, Portugal in 2022.
-
-The name Assemble is a reference to Meltano being used to assemble a data stack/pipeline. At Assemble the entire all-remote team gathers to bond and meet face-to-face. We pick a new location every year and invite the entire team to join in for 5 days. There is nothing like meeting someone in person whom you have only ever seen virtually.
+The name Assemble is a reference to Meltano being used to assemble a data stack/pipeline. At Assemble the entire all-remote team gathers to bond and meet face-to-face. We pick a new location for each event and invite the entire team to join in for 5 days. There is nothing like meeting someone in person whom you have only ever seen and worked with virtually.
 
 Our favorite definition of “assemble” is, “fit together the separate component parts.” That is what this event feels like – everyone coming from different parts of the world, bringing their range of experiences to become one. And somehow, we all fit together to become a better whole.
 
-Read more about our last [Assemble in Mexico City](https://www.google.com/url?q=https://meltano.com/blog/assemble-2021-mexico-city-roundup/&sa=D&source=docs&ust=1639515528558000&usg=AOvVaw0LZpL5Jgj_b6bKnswXwKgE).
+Assemble 2021 took place in beautiful Mexico City. Assemble 2022 took place in Lisbon, Portugal, in March 2022.
+
+Read about [Assemble in Mexico City here](https://www.google.com/url?q=https://meltano.com/blog/assemble-2021-mexico-city-roundup/&sa=D&source=docs&ust=1639515528558000&usg=AOvVaw0LZpL5Jgj_b6bKnswXwKgE).  Read about [Assemble in Lisbon, Portugal, here](https://meltano.com/blog/assemble-recap-company-on-site-in-lisbon/).
 
 #### Carbon Offsets
 

--- a/src/_peopleops/index.md
+++ b/src/_peopleops/index.md
@@ -11,7 +11,7 @@ We're currently using [Greenhouse](https://www.greenhouse.io/) to manage the hir
 
 ### Adding New Roles
 
-- Open an issue on the [administration](https://gitlab.com/meltano/administration/) using the `new-job-creation.md` template.
+- Open an issue in the [administration](https://github.com/meltano/administration/issues) repository using the `new-job-creation.md` template.
 - Fill out necessary details. All sections are required unless they're marked optional. Having all of this information helps us get the job online and ensures all candidates are evaluated based on the same interview process. This is just an initial version of the hiring process -- it can always be iterated on.
 - A Site Admin will add the role to Greenhouse once the issue has been filled out and approved.
 - Site Admin will add the hiring manager as a job admin to this role.


### PR DESCRIPTION
This addresses most of the remaining handbook issues related to the GitLab->GitHub migration