### PR TITLE
PTO notification policy clarifications

### DIFF
--- a/src/_peopleops/benefits.md
+++ b/src/_peopleops/benefits.md
@@ -43,7 +43,7 @@ We offer a 1 month paid sabbatical every 2 years of your employment. All full ti
 
 Taking more than 3 weeks consecutively requires explicit approval outside of the 2-yearly sabbatical. In other words, anything up to 3 business weeks can be taken off without approval.
 
-To log time off, team members should use [PTO by Roots](/company/tech-stack/#pto-by-roots) in Slack (under Apps).  Please try to do so **at least 2 weeks** prior to the date(s) you intend to take off.
+To log time off, team members should use [PTO by Roots](/company/tech-stack/#pto-by-roots) in Slack (under Apps).  In general, please try to do so **at least 2 weeks** prior to the date(s) you intend to take off so we can plan for your absence.  Should you require time off for medical reasons, please log your absence when you know you will be out.
 
 Follow the instructions in [Tracking Time Off](/peopleops/calendars#tracking-time-off) to indicate your PTO.
 

--- a/src/_peopleops/calendars.md
+++ b/src/_peopleops/calendars.md
@@ -16,7 +16,7 @@ weight: 2
 
 ## Tracking Time Off
 
-Use [PTO by Roots](/company/tech-stack/#pto-by-roots) to add time off to the calendar, preferably **at least 2 weeks** before the day off.  Holidays, Family and Friend Days, and Paid Time Off (PTO) are all tracked via this tool.  It is important for everyone to add time off to the calendar in advance so the team knows who will be out when and can plan accordingly.  This does not mean that all PTO requires two weeks of advanced notice.  If you are sick or are scheduling a medical appointment, for example, get yourself help ASAP but do make sure to log your time off.
+Use [PTO by Roots](/company/tech-stack/#pto-by-roots) to add time off to the calendar, preferably **at least 2 weeks** before the day off.  Holidays, Family and Friend days, and Paid Time Off (PTO) are all tracked via this tool.  It is important for everyone to add time off to the calendar in advance when possible so the team knows who will be out when and can plan accordingly.  This does not mean that all PTO requires two weeks of advanced notice.  If you are sick or are scheduling a medical appointment, for example, get yourself help ASAP but do make sure to log your time off.
 
 ### Short-term Leave
 

--- a/src/_peopleops/calendars.md
+++ b/src/_peopleops/calendars.md
@@ -16,7 +16,7 @@ weight: 2
 
 ## Tracking Time Off
 
-Use [PTO by Roots](/company/tech-stack/#pto-by-roots) to add time off to the calendar, preferably **at least 2 weeks** before the day off.  Holidays, Family and Friend Days, and Paid Time Off (PTO) are all tracked via this tool.  It is important for everyone to add time off to the calendar in advance so the team knows who will be out when and can plan accordingly.
+Use [PTO by Roots](/company/tech-stack/#pto-by-roots) to add time off to the calendar, preferably **at least 2 weeks** before the day off.  Holidays, Family and Friend Days, and Paid Time Off (PTO) are all tracked via this tool.  It is important for everyone to add time off to the calendar in advance so the team knows who will be out when and can plan accordingly.  This does not mean that all PTO requires two weeks of advanced notice.  If you are sick or are scheduling a medical appointment, for example, get yourself help ASAP but do make sure to log your time off.
 
 ### Short-term Leave
 


### PR DESCRIPTION
Clarify that for medical reasons 2 weeks of notice is absolutely not necessary and that employees should seek treatment right away if they need to do so.