### PR TITLE
Add link to HubSpot page on tech stack

### DIFF
--- a/src/_company/tech-stack.md
+++ b/src/_company/tech-stack.md
@@ -150,9 +150,7 @@ Payroll and benefits platform for US-based team members.
 
 ## [HubSpot](https://www.hubspot.com/)
 
-Customer relationship management (CRM) and marketing automation platform (MAP).
-
-HubSpot Insights can only enrich company data if the company name is pulled in: https://knowledge.hubspot.com/companies/hubspot-insights-on-company-records
+Customer relationship management (CRM) and marketing automation platform (MAP). [Visit marketing ops to learn more](https://handbook.meltano.com/marketing/marketing-ops/hubspot).
 
 ## [Instagram](https://www.instagram.com/)
 


### PR DESCRIPTION
Add link to HubSpot page under /marketing-ops for HubSpot listing on tech stack page