### PR TITLE
Document ways to communicate weekly priorities - replace weekly kickoff references

### DIFF
--- a/src/_company/communication.md
+++ b/src/_company/communication.md
@@ -25,7 +25,7 @@ While asynchronous communication is strongly preferred, there are scenarios in w
 ## In practice
 
 1. Aim to respond to mentions other than FYIs within 3 business days. If you are unable to fulfill a specific request during that time, respond to the mention and indicate when you'll have an answer.
-1. If you're behind on responding to notifications and expect to miss a deadline for any new mentions (until you're caught up), please inform the team in the Kickoff, and ask that urgent requests be sent to you via Slack DM and include the issue/MR link.
+1. If you're behind on responding to notifications and expect to miss a deadline for any new mentions (until you're caught up), please inform the team via Slack in `#internal-chatter` or the relevant department channel, and ask that urgent requests be sent to you via Slack DM including the relevant issue/PR link.
 1. Use direct language when communicating. If you want someone to take action, directly tell them what's required, and when you need an answer, and whether there is urgency. Also indicate whether something is a "must have" or "nice to have" when asking for collaboration.
 1. Over-communication can be appropriate. You can mention someone in an issue, but we all know that sometimes we can miss something, so if a request has stagnated, you can send someone a direct message as a gentle reminder. If you need something urgently, you can also send a Slack message to request that something is prioritized.
 

--- a/src/_company/leadership.md
+++ b/src/_company/leadership.md
@@ -15,3 +15,5 @@ The Meltano Leadership team is:
 The leadership team meets 2-4 times per month to have cross-functional discussions about how to best move the business forward.
 
 Any changes (new processes, handbook updates) that impact all departments need to be discussed in at least one leadership call to make sure everyone is on board before getting merged.
+
+Every Monday, leadership team members will post to `#internal-announcements` on what their departments are working on for the week to push the company priorities forward.

--- a/src/_marketing/content.md
+++ b/src/_marketing/content.md
@@ -146,14 +146,13 @@ Meltano posts numerous videos to YouTube each week, covering everything from pro
 Videos uploaded to YouTube should have names that try and follow the same format wherever possible.
 
 - They always start with “Meltano"
-- They then describe the type of recording (Weekly Kickoff, Meeting, Speedrun, Release, Discussion, etc)
+- They then describe the type of recording (Meeting, Speedrun, Release, Discussion, etc)
 - If there’s a specific version of Meltano being referenced, (in a speedrun or release), reference it with a lower-case v followed by the release number (`v1.3.0`)
 - Finish with the date in YYYY-MM-DD (`2019-11-01`)
 - Separate all names with dashes
 
 Examples of great YouTube video names include:
 
-- Meltano Weekly Kickoff - 2019-10-31
 - Meltano Release - v1.3.0 - 2019-10-31
 - Meltano Meeting - Marketing Planning - 2019-10-31
 - Meltano Discussion - Singer Tap Brainstorming - 2019-10-31

--- a/src/_marketing/index.md
+++ b/src/_marketing/index.md
@@ -13,7 +13,6 @@ The Meltano convenes regularly to generate content for community and learning pu
 
 These items include:
 
-- **Weekly Kickoff**: Livestream each Monday covering what will be worked on during the week
 - **Office Hours**: Community meeting for discussion about upcoming features and general Q&A
 - **Demo Day**: Community meeting every other Thursday showing off what has shipped, demonstrated by each authoring participant as available
 - **Meltano / SDK Release**: the actual software release, which generates a changelog, version number, and all of the previous content for the week
@@ -22,7 +21,7 @@ Each item (linked below) has a corresponding guide to promoting that activity. E
 
 | Day       | Content                                                   |
 | --------- | --------------------------------------------------------- |
-| Monday    | Kickoff blog & promotion, Monday release blog & promotion |
+| Monday    | Release blog & promotion |
 | Tuesday   | Social promotion of weekly activity                       |
 | Wednesday | Social promotion of weekly activity                       |
 | Thursday  | Thursday release blog & promotion, weekly newsletter      |

--- a/src/_peopleops/calendars.md
+++ b/src/_peopleops/calendars.md
@@ -8,7 +8,6 @@ weight: 2
 
 - [Community Meetings Calendar](https://calendar.google.com/calendar/u/1?cid=Y18wMWNqNDhoYTRoMTk5Y3RqZWZpODV0OWRnY0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t) - Meetings open to the community
 - Team Meetings: Meetings with the team
-  - Kick off: Weekly on Monday, owned by Douwe
 - External Meetings: Meetings with users and partners
 - Time Off: All-day events for periods team members will not be working
 

--- a/src/_product/index.md
+++ b/src/_product/index.md
@@ -100,7 +100,7 @@ Every Monday we will highlight for the team what the priorities are for the week
 In addition, the following should also be done:
 - Review and roll community issues to the next milestone
 - Roll merge requests
-- Everyone on the team should roll their own issues to the next milestone. Take the time to review the current status of issues and align priorities with the kickoff issue.
+- Everyone on the team should roll their own issues to the next milestone. Take the time to review the current status of issues and align priorities within the team.
 - Close the previous milestone
 
 ## Open Source Projects We're Keeping an Eye On

--- a/src/_product/index.md
+++ b/src/_product/index.md
@@ -93,38 +93,15 @@ Sometimes, it can feel like we are chosing between two important things and this
 
 Meltano uses weekly milestones to track work. They are named for the Friday on which the milestone ends, i.e. `Fri: July 9, 2021`.
 
-### Weekly Kickoff
+### Weekly Tasks
 
-Every Monday we have a Kickoff call to highlight for the community what the priorities are for the week. Prior to the actual call, there are several work items to do.
+Every Monday we will highlight for the team what the priorities are for the week by posting in `#internal-announcements` with links to projects and issues where more context can be found and questions can be asked.
 
-#### Friday - Last day of Milestone
-
-- Create a kickoff issue highlighting the general priority for the next week.
-  - Title: `Weekly Kickoff for Milestone - <milestone>`
-  - Due Date for the Monday of the milestone
-
-#### Monday - Kickoff Day
-
-Before the Kickoff Call:
-
+In addition, the following should also be done:
 - Review and roll community issues to the next milestone
 - Roll merge requests
 - Everyone on the team should roll their own issues to the next milestone. Take the time to review the current status of issues and align priorities with the kickoff issue.
-
-Kickoff Call:
-
-- Check-in with everyone
-- Highlights & lowlights from previous week
-- Confirm general priorities and do a soft review of boards
-- Review Metrics
-- Start livestream
-  - Talk about general priority
-  - Walk through issues
-
-After the Kickoff Call:
-
 - Close the previous milestone
-- Close Kickoff issue
 
 ## Open Source Projects We're Keeping an Eye On
 


### PR DESCRIPTION
This PR replaces handbook references to the weekly kickoff.