### PR TITLE
Updated `nokogiri` to > 1.12.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     algolia_html_extractor (2.6.4)
       json (~> 2.0)
       nokogiri (~> 1.10)
@@ -14,16 +14,16 @@ GEM
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
-    ethon (0.15.0)
+    ethon (0.16.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
-    ffi (1.15.4)
+    ffi (1.15.5)
     filesize (0.2.0)
     forwardable-extended (2.6.0)
-    html-proofer (3.19.2)
+    html-proofer (3.19.3)
       addressable (~> 2.3)
       mercenary (~> 0.3)
-      nokogumbo (~> 2.0)
+      nokogiri (~> 1.12)
       parallel (~> 1.3)
       rainbow (~> 3.0)
       typhoeus (~> 1.3)
@@ -77,15 +77,13 @@ GEM
     mercenary (0.4.0)
     nokogiri (1.12.5-arm64-darwin)
       racc (~> 1.4)
-    nokogumbo (2.0.5)
-      nokogiri (~> 1.8, >= 1.8.4)
-    parallel (1.21.0)
+    parallel (1.22.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     progressbar (1.11.0)
-    public_suffix (4.0.6)
+    public_suffix (5.0.1)
     racc (1.6.0)
-    rainbow (3.0.0)
+    rainbow (3.1.1)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -106,6 +104,7 @@ GEM
 PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
+  arm64-darwin-22
 
 DEPENDENCIES
   html-proofer (~> 3.19)


### PR DESCRIPTION
`bundle install` was not able to install `nokogumbo` on Apple M1. Updated `nokogiri` to > 1.12.0 and removed `nokogumbo` dependencies. Also ran `bundle update html-proofer` to switch it's dependency from `nokogumbo` to `nokogiri`.