### PR TITLE
Update PTO Tracker Name

### DIFF
--- a/src/_company/tech-stack.md
+++ b/src/_company/tech-stack.md
@@ -238,9 +238,9 @@ Downtime alerts for the properties listed under [Outages & escalation](/engineer
 
 Account details are in the `Engineering` 1Password vault.
 
-## [PTO by Roots](https://meltano.slack.com/apps/AELEX1TU3-pto-by-roots)
+## [PTO by Deel](https://meltano.slack.com/apps/AELEX1TU3-pto-by-deel?tab=more_info)
 
-[PTO by Roots](https://www.tryroots.io/pto) allows employees and managers to coordinate their [time off](/peopleops/calendars#tracking-time-off) seamlessly with intuitive Slack commands. PTO by Roots also reminds employees of their upcoming time off and helps them assign roles and tasks for co-workers, giving all parties involved greater alignment and peace of mind.
+[PTO by Deel](https://www.deel.com/engage/pto) allows employees and managers to coordinate their [time off](/peopleops/calendars#tracking-time-off) seamlessly with intuitive Slack commands. PTO by Deel also reminds employees of their upcoming time off and helps them assign roles and tasks for co-workers, giving all parties involved greater alignment and peace of mind.
 
 Every team member has access through their [Slack](#slack) account (under Apps).
 


### PR DESCRIPTION
Our PTO tracker has a new name. Instead of PTO by Roots it is now PTO by Deel.