### PR TITLE
Add height to table of contents and scroll on overflow

### DIFF
--- a/css/handbook.css
+++ b/css/handbook.css
@@ -255,6 +255,10 @@ code {
 
 .toc {
   position: fixed;
+  /* 100vh - (navbarHeight + margin + extra padding on scroll) - footerHeight */
+  height: calc(100vh - 160px - 260px);
+  overflow-y: auto;
+  margin-right: 1rem;
 }
 
 .toc h2 {


### PR DESCRIPTION
The table of contents on a couple of pages seemed to overflow into the footer and make it difficult to use the table of contents to navigate. I Added a height to the table of contents calculated by (100vh - navbar - extra scroll padding - footer) so that the table of contents should always persist above the footer on scroll. 

Pages where this happened: 
- Anti-Harassment Policy
- Tech Stack
- DATA TEAM / SQL Style Guide
- Stable increments

I have attached some before and after photos to show what it looks like
<img width="283" alt="Screenshot 2023-06-06 at 5 54 32 PM" src="https://github.com/meltano/handbook/assets/14004680/0c77db56-dd13-439f-806b-80c2806e4276">
<img width="295" alt="Screenshot 2023-06-06 at 5 54 40 PM" src="https://github.com/meltano/handbook/assets/14004680/6617a570-2e97-4d32-a878-edd781fb1c6a">
<img width="1476" alt="Screenshot 2023-06-06 at 5 54 52 PM" src="https://github.com/meltano/handbook/assets/14004680/a441b901-0917-48b2-a58a-d72af1c9d6c8">
<img width="1454" alt="Screenshot 2023-06-06 at 5 55 04 PM" src="https://github.com/meltano/handbook/assets/14004680/25b193a3-687f-45cc-9cc2-c79dd3d41123">
<img width="1469" alt="Screenshot 2023-06-06 at 5 55 30 PM" src="https://github.com/meltano/handbook/assets/14004680/1c2ff4e9-893e-4bd5-a6da-50369f9456b9">
<img width="1454" alt="Screenshot 2023-06-06 at 5 55 36 PM" src="https://github.com/meltano/handbook/assets/14004680/f4277cc3-542b-4732-a6b2-1007d996e6d6">

